### PR TITLE
update build/release configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,23 +18,18 @@ env:
   PROGRAM_NAME: gridgen
 jobs:
   build:
-    name: Build and Test on ${{ matrix.os }} with ${{ matrix.compiler }} ${{ matrix.version }}
+    name: ${{ matrix.os }} ${{ matrix.compiler }} ${{ matrix.version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # test latest gcc
-          - {os: ubuntu-latest, compiler: gcc, version: 13, shell: bash, release: no}
+          # gcc
+          - {os: ubuntu-22.04, compiler: gcc, version: 13, shell: bash, release: no}
           - {os: macos-14, compiler: gcc, version: 13, shell: bash, release: yes}
-          - {os: macos-15-intel, compiler: gcc, version: 13, shell: bash, release: yes}          
-          - {os: windows-latest, compiler: gcc, version: 13, shell: pwsh, release: no}
-          # test intel-classic
+          - {os: windows-2022, compiler: gcc, version: 13, shell: pwsh, release: no}
+          # intel
           - {os: ubuntu-22.04, compiler: intel-classic, version: 2021.7, shell: bash, release: no}
-          # test previous gcc
-          - {os: ubuntu-latest, compiler: gcc, version: 12, shell: bash, release: no}
-          - {os: ubuntu-latest, compiler: gcc, version: 11, shell: bash, release: no}
-          # test ifx
           - {os: ubuntu-22.04, compiler: intel, version: "2025.0", shell: bash, release: yes}
           - {os: windows-2022, compiler: intel, version: "2025.0", shell: pwsh, release: yes}
     defaults:

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,12 +12,12 @@ modflow-devtools = "*"
 
 [tasks]
 
-# meson build for gridgen
+# build
 clean = { cmd = "rm -rf builddir" }
 setup = { cmd = "meson setup --prefix=$(pwd) --bindir=bin builddir", env = { PKG_CONFIG_PATH = "$CONDA_PREFIX/lib/pkgconfig" } }
 build = "meson install -C builddir"
 
-# test gridgen
+# test
 test = { cmd = "meson test --verbose --no-rebuild -C builddir initial write_data shapefileA shapefileB shapefileC shapefileD intersectA intersectB vtkA vtkB vtkC" }
 test-initial = { cmd = "meson test --verbose --no-rebuild -C builddir initial" }
 test-write = { cmd = "meson test --verbose --no-rebuild -C builddir write_data" }
@@ -25,5 +25,5 @@ test-shapefile = { cmd = "meson test --verbose --no-rebuild -C builddir shapefil
 test-intersect = { cmd = "meson test --verbose --no-rebuild -C builddir intersectA intersectB" }
 test-vtk = { cmd = "meson test --verbose --no-rebuild -C builddir vtkA vtkB vtkC" }
 
-# get ostag for system
+# ostag
 get-ostag = { cmd = "python -c 'from modflow_devtools.ostags import get_ostag; print(get_ostag())'"} 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "gridgen"
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "linux-aarch64", "osx-arm64", "osx-64"]


### PR DESCRIPTION
* drop Intel Mac build
* drop unsupported gcc tests
* fix "project" -> "workspace" in pixi.toml
* pin specific versions of runner images (oldest available for build compatibility)